### PR TITLE
Added support to PIC18F4580 and possibility of multiple BRG configura…

### DIFF
--- a/pic/common/can18f.c
+++ b/pic/common/can18f.c
@@ -126,10 +126,16 @@ void vscp18f_init(BOOL bExtended) {
     // SAM = 0
     // Seg2 Freely prog.
     // Phaseseg2 = 2
+#if (_XTAL_FREQ == 32000000)
+    BRGCON1 = 0x07;
+    BRGCON2 = 0xac;
+    BRGCON3 = 0x03;
+#else
     BRGCON1 = 0x09;
     BRGCON2 = 0xbc;
     BRGCON3 = 0x01;
-
+#warning("Current crystal frequency is not supported")
+#endif
     // Receive only valid extended messages
     // Receive buffer 0 overflow will write to buffer 1
     if (bExtended) {
@@ -359,12 +365,22 @@ BOOL vscp18f_sendMsg(uint32_t id, uint8_t* data, uint8_t dlc, uint8_t flags) {
     //
 
 #if defined(MCHP_C18)
-    _asm
-    bsf RXB0CON, 3, 0
-            _endasm
+    #if defined(__18F248) || defined(__18F258) ||defined(__18F448) || defined(__18F458)
+        _asm
+        bsf RXB0CON, 3, 0
+                _endasm
+    #else
+        #error "PIC 18Fxxx(x) not supported."
+    #endif
 #endif
 #if defined(HITECH_C18)
-            asm("bsf _RXB0CON,3");
+    #if defined(__18F248) || defined(__18F258) ||defined(__18F448) || defined(__18F458)
+        asm("bsf _RXB0CON,3");
+    #elif defined(__18F2480) || defined(__18F2580)  ||defined(__18F4480) || defined(__18F4580)
+        RXB0RTRR0 = 1;
+    #else
+    #error "PIC 18Fxxx(x) not supported."
+    #endif
 #endif
 
     //
@@ -400,12 +416,12 @@ BOOL vscp18f_readMsg(uint32_t *id, uint8_t *data, uint8_t *dlc, uint8_t *flags) 
         PIR3bits.RXB0IF = 0;
 
         // Record and forget any previous overflow 
-#if defined(__18F248) || defined(__18F258)       
+#if defined(__18F248) || defined(__18F258) ||defined(__18F448) || defined(__18F458)
         if (COMSTATbits.RXB0OVFL) {
             *flags |= CAN_RX_OVERFLOW;
             COMSTATbits.RXB0OVFL = 0;
         }
-#elif defined(__18F2480) || defined(__18F2580)
+#elif defined(__18F2480) || defined(__18F2580) ||defined(__18F4480) || defined(__18F4580)
         if (COMSTATbits.RXB0OVFL) {
             *flags |= CAN_RX_OVERFLOW;
             COMSTATbits.RXB0OVFL = 0;
@@ -443,12 +459,12 @@ BOOL vscp18f_readMsg(uint32_t *id, uint8_t *data, uint8_t *dlc, uint8_t *flags) 
         PIR3bits.RXB1IF = 0;
 
         // Record and forget any previous overflow
-#if defined(__18F248) || defined(__18F258)        
+#if defined(__18F248) || defined(__18F258) ||defined(__18F448) || defined(__18F458)
         if (COMSTATbits.RXB0OVFL) {
             *flags |= CAN_RX_OVERFLOW;
             COMSTATbits.RXB1OVFL = 0;
         }
-#elif defined(__18F2480) || defined(__18F2580) 
+#elif defined(__18F2480) || defined(__18F2580)  ||defined(__18F4480) || defined(__18F4580)
         if (COMSTATbits.RXB0OVFL) {
             *flags |= CAN_RX_OVERFLOW;
             COMSTATbits.RXB1OVFL = 0;

--- a/pic/common/can18f.h
+++ b/pic/common/can18f.h
@@ -72,9 +72,11 @@
 #error "Compiler not supported."
 #endif
 
+#if !defined(_BOOL)
 typedef enum _BOOL {
     FALSE = 0, TRUE
 } BOOL;
+#endif
 
 // CAN 18F operation modes
 #define CAN18F_MODE_BITS	0b11100000


### PR DESCRIPTION
…tion selected using _XTAL_FREQ definition

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/grodansparadis/vscp_firmware/6)
<!-- Reviewable:end -->
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/grodansparadis/vscp_firmware/pull/6%23issuecomment-106263856%22%2C%20%22https%3A//github.com/grodansparadis/vscp_firmware/pull/6%23issuecomment-106274239%22%2C%20%22https%3A//github.com/grodansparadis/vscp_firmware/pull/6%23issuecomment-106274249%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/grodansparadis/vscp_firmware/pull/6%23issuecomment-106263856%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Hello%2C%5Cr%5Cn%5Cr%5CnI%20added%20the%20support%20to%20new%20Microchip%20devices%20PIC18F%2A580.%5Cr%5Cn%5Cr%5CnMoreover%2C%20I%20added%20the%20oppportunity%20to%20save%20several%20BRG%20configuration%20based%20on%20Crystal%20frequency%20than%20select%20it%20defining%20_XTAL_FREQ%20in%20vscp_projdefs.h%5Cr%5Cn%5Cr%5CnFor%20backcompatibility%2C%20in%20case%20of%20mission%20definition%2C%20a%20warning%20is%20risen%20at%20compiling%20time%20and%20default%20values%20are%20used.%5Cr%5Cn%5Cr%5CnBest%20Regards%2C%5Cr%5CnSalvo%22%2C%20%22created_at%22%3A%20%222015-05-28T10%3A23%3A56Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6265510%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/nos86%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3Ashipit%3A%22%2C%20%22created_at%22%3A%20%222015-05-28T10%3A57%3A33Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1358883%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/grodansparadis%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3Ashipit%3A%22%2C%20%22created_at%22%3A%20%222015-05-28T10%3A57%3A34Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1358883%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/grodansparadis%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%2C%20%22approved%22%3A%20%7B%22https%3A//github.com/grodansparadis%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1358883%3Fv%3D3%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>

<img src='http://www.codereviewhub.com/site/github-approved-avatar.png'><a href='https://github.com/grodansparadis'><img src='https://avatars.githubusercontent.com/u/1358883?v=3' width=34 height=34></a>

- [x] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/grodansparadis/vscp_firmware/pull/6#issuecomment-106263856'>General Comment</a></b>
- <a href='https://github.com/nos86'><img border=0 src='https://avatars.githubusercontent.com/u/6265510?v=3' height=16 width=16'></a> Hello,
I added the support to new Microchip devices PIC18F*580.
Moreover, I added the oppportunity to save several BRG configuration based on Crystal frequency than select it defining _XTAL_FREQ in vscp_projdefs.h
For backcompatibility, in case of mission definition, a warning is risen at compiling time and default values are used.
Best Regards,
Salvo


<a href='https://www.codereviewhub.com/grodansparadis/vscp_firmware/pull/6?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/grodansparadis/vscp_firmware/pull/6?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/grodansparadis/vscp_firmware/pull/6?approve=0'><img src='http://www.codereviewhub.com/site/github-undo-approve.png' height=26></a>&nbsp;<a href='https://github.com/grodansparadis/vscp_firmware/pull/6'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>