### PR TITLE
extended page read: reading of 256 registers enabled

### DIFF
--- a/avr/digiprobe_gcc/vscp_mandatory.c
+++ b/avr/digiprobe_gcc/vscp_mandatory.c
@@ -301,7 +301,7 @@ uint8_t vscp_getSubzone( void )
 //	to the selected protocol. 
 //
 
-void vscp_goBootloaderMode( void )
+void vscp_goBootloaderMode( uint8_t algorithm )
 {
 	// TODO
 }

--- a/avr/digiprobe_gcc/vscp_mandatory.h
+++ b/avr/digiprobe_gcc/vscp_mandatory.h
@@ -56,7 +56,7 @@ void vscp_wait_s(uint16_t tsec);
 
 	uint8_t vscp_getSubzone( void );
 
-	void vscp_goBootloaderMode( void );
+	void vscp_goBootloaderMode( uint8_t );
 
 	uint8_t vscp_getMajorVersion();
 

--- a/common/vscp_firmware.c
+++ b/common/vscp_firmware.c
@@ -1155,8 +1155,8 @@ void vscp_handleProtocolEvent(void)
 
             if ( vscp_nickname == vscp_imsg.data[0] ) {
 
-                uint16_t page_save;
-                uint8_t byte = 0, bytes = 0;
+                uint16_t page_save, bytes = 0;
+                uint8_t byte = 0;
                 uint8_t bytes_this_time, cb;
 
                 // if data byte 4 of the request is present probably more than 1 register should be
@@ -1164,11 +1164,11 @@ void vscp_handleProtocolEvent(void)
                 if ( ( vscp_imsg.flags & 0x0f) > 3 ) {
 
                     // Number of registers was specified', thus take that value
-                    bytes = vscp_imsg.data[4];
-                    // if number of bytes was zero we read one byte 
-                    if ( 0 == bytes ) {
-                        bytes = 1;
-					} 
+                    bytes = (uint16_t)vscp_imsg.data[4];
+                    // if number of bytes was zero we read 256 bytes
+                    if (bytes == 0) bytes = 256;
+                    // insane range checking
+                    if (bytes > 256) bytes = 256;
 				}
 				else {
 					bytes = 1;


### PR DESCRIPTION
Added the feature to read 256 registers with extended page read by specifying byte 4 = zero.
Second commit just to make digiprobe demo compile flawless.
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/grodansparadis/vscp_firmware/pull/9?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/grodansparadis/vscp_firmware/pull/9'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/grodansparadis/vscp_firmware/9)
<!-- Reviewable:end -->
